### PR TITLE
fixed checking TTL when committing secondary rows

### DIFF
--- a/themis-coprocessor/src/main/java/org/apache/hadoop/hbase/themis/cp/ThemisEndpoint.java
+++ b/themis-coprocessor/src/main/java/org/apache/hadoop/hbase/themis/cp/ThemisEndpoint.java
@@ -426,7 +426,10 @@ public class ThemisEndpoint extends ThemisService implements CoprocessorService,
     long beginTs = System.nanoTime();
     try {
       checkFamily(mutations);
-      checkWriteTTL(System.currentTimeMillis(), prewriteTs, row);
+      // only committing primary row need to care about writeTTL
+      if (primaryIndex != -1) {
+        checkWriteTTL(System.currentTimeMillis(), prewriteTs, row);
+      }
       return new MutationCallable<Boolean>(row) {
         public Boolean doMutation(HRegion region, RowLock rowLock) throws IOException {
           if (primaryIndex >= 0) {


### PR DESCRIPTION
fixed the second issue in https://github.com/XiaoMi/themis/issues/5
